### PR TITLE
fix(logger): correct nil check in Close() to ensure Sync is called

### DIFF
--- a/zlog/zlog.go
+++ b/zlog/zlog.go
@@ -100,7 +100,7 @@ type ZLog struct {
 }
 
 func Close() {
-	if defaultLogger != nil {
+	if defaultLogger == nil {
 		return
 	}
 	_ = defaultLogger.provider.Sync()


### PR DESCRIPTION
### 修复内容
修复了 `Close()` 函数中错误的判空逻辑，避免在 logger 存在时提前 return，导致未调用 Sync。

### 关联 Issue
Fixes #1 