### PR TITLE
fix: Avoid sync.Pool reuse data race

### DIFF
--- a/flow/flow.go
+++ b/flow/flow.go
@@ -504,12 +504,13 @@ func Capture(device string, pool *async.WorkerPool, w *Window) {
 					Bytes:     float64(packetLen),
 					Requests:  1,
 				}
+				copied := *stats
+				syncPool.Put(stats)
 				if conf.CoreConf.Kafka.Enable {
-					msg, _ := json.Marshal(stats)
+					msg, _ := json.Marshal(copied)
 					kafka.Push(msg)
 				}
-				w.Add(*stats)
-				syncPool.Put(stats)
+				w.Add(copied)
 				return nil
 			}, packet)
 		case <-ticker.C:


### PR DESCRIPTION
This patch ensures that objects fetched from `sync.Pool` are copied before being used elsewhere (e.g., in Kafka, metrics, or buffered channels). This prevents potential data corruption when the pooled object is reused.

- Fixed: potential data race by copying `*Traffic` before reuse
- Safe usage with Kafka and downstream consumers